### PR TITLE
Remove check for http status code 

### DIFF
--- a/Sources/RequestOperation/Publisher/URLSession+SendUrlRequest.swift
+++ b/Sources/RequestOperation/Publisher/URLSession+SendUrlRequest.swift
@@ -11,20 +11,12 @@ import Combine
 
 extension URLSession {
     
-    public func sendUrlRequestPublisher(urlRequest: URLRequest) -> AnyPublisher<UrlRequestResponse, Error> {
+    public func sendUrlRequestPublisher(urlRequest: URLRequest) -> AnyPublisher<UrlRequestResponse, URLError> {
         
         return dataTaskPublisher(for: urlRequest)
-            .tryMap {
+            .map { (object: (data: Data, response: URLResponse)) in
                 
-                let data: Data = $0.data
-                let urlResponse: URLResponse = $0.response
-                
-                let urlRequestResponse = UrlRequestResponse(data: data, urlResponse: urlResponse)
-                
-                if let serverError = urlRequestResponse.getServerError() {
-                    
-                    throw serverError
-                }
+                let urlRequestResponse = UrlRequestResponse(data: object.data, urlResponse: object.response)
                 
                 return urlRequestResponse
             }


### PR DESCRIPTION
Removing logic to throw an error if the http status code is an unsuccessful status code.  Going to keep this as close to the URLSession dataTaskPublisher as possible (https://developer.apple.com/documentation/foundation/urlsession/3329707-datataskpublisher)