### PR TITLE
Add option to override url session

### DIFF
--- a/Sources/RequestOperation/RequestSender/RequestSender.swift
+++ b/Sources/RequestOperation/RequestSender/RequestSender.swift
@@ -18,7 +18,9 @@ open class RequestSender {
         self.session = session
     }
     
-    open func sendDataTaskPublisher(urlRequest: URLRequest) -> AnyPublisher<RequestDataResponse, Error> {
+    open func sendDataTaskPublisher(urlRequest: URLRequest, urlSession: URLSession? = nil) -> AnyPublisher<RequestDataResponse, Error> {
+        
+        let session: URLSession = urlSession ?? self.session
         
         return session.dataTaskPublisher(for: urlRequest)
             .map { (tuple: (data: Data, response: URLResponse)) in


### PR DESCRIPTION
Adding option to override the URLSession on RequestSender when sending a URLRequest.

@rachaelblue Currently RequestSender is initialized with a URLSession and that URLSession instance is used when sending a request.  I'm considering removing URLSession from the initializer and forcing it when sending a URLRequest.  This way the same RequestSender could be shared regardless of the URLSession.  