### PR TITLE
Force URLSession when sending URLRequest through RequestSender

### DIFF
--- a/Example/MobileContentApi/App/Share/Data/MobileContentApi/MobileContentApi.swift
+++ b/Example/MobileContentApi/App/Share/Data/MobileContentApi/MobileContentApi.swift
@@ -16,17 +16,17 @@ class MobileContentApi: RequestApi {
         
         let baseUrl: ApiBaseUrl = environment.baseUrl
         
-        let session: URLSession = RequestUrlSession.sharedIgnoreCacheSession
+        let urlSession: URLSession = RequestUrlSession.sharedIgnoreCacheSession
         
         let requestController = RequestController(
             requestBuilder: RequestBuilder(),
-            requestSender: RequestSender(session: session),
+            requestSender: RequestSender(),
             requestRetrier: nil
         )
         
         let context = RequestApiSharedContext(
             baseUrl: baseUrl,
-            session: session,
+            urlSession: urlSession,
             requestController: requestController
         )
         

--- a/Example/MobileContentApi/App/Share/Data/MobileContentApi/Resources/Language/Endpoints/GetLanguageEndpoint.swift
+++ b/Example/MobileContentApi/App/Share/Data/MobileContentApi/Resources/Language/Endpoints/GetLanguageEndpoint.swift
@@ -11,17 +11,27 @@ import Combine
 
 class GetLanguageEndpoint: ApiEndpoint {
     
+    private let urlSession: URLSession
+    
+    init(urlSession: URLSession, resourceUrl: ApiResourceUrl, context: RequestApiSharedContext) {
+        
+        self.urlSession = urlSession
+        
+        super.init(resourceUrl: resourceUrl, requestController: context.requestController)
+    }
+    
     func getLanguage(id: String) -> AnyPublisher<LanguageModel?, Never> {
         
         return requestController.buildAndSendRequestPublisher(
+            urlSession: urlSession,
             urlString: resourceUrl.absoluteUrl + "/" + id,
             method: .get,
             headers: MobileContentApiHeaders.nonAuthorizedHeaders().getHeadersValue(),
             httpBody: nil,
             queryItems: nil
         )
-        .map { (response: RequestCodableResponse<JsonApiResponseDataObject<LanguageModel>>) in
-            return response.codable?.data
+        .map { (response: RequestCodableResponse<JsonApiResponseDataObject<LanguageModel>, NoResponseCodable>) in
+            return response.successCodable?.dataObject
         }
         .catch { _ in
             return Just(nil)

--- a/Example/MobileContentApi/App/Share/Data/MobileContentApi/Resources/Language/Endpoints/GetLanguagesEndpoint.swift
+++ b/Example/MobileContentApi/App/Share/Data/MobileContentApi/Resources/Language/Endpoints/GetLanguagesEndpoint.swift
@@ -11,17 +11,27 @@ import Combine
 
 class GetLanguagesEndpoint: ApiEndpoint {
     
+    private let urlSession: URLSession
+    
+    init(urlSession: URLSession, resourceUrl: ApiResourceUrl, context: RequestApiSharedContext) {
+        
+        self.urlSession = urlSession
+        
+        super.init(resourceUrl: resourceUrl, requestController: context.requestController)
+    }
+    
     func getLanguages() -> AnyPublisher<[LanguageModel], Never> {
         
         return requestController.buildAndSendRequestPublisher(
+            urlSession: urlSession,
             urlString: resourceUrl.absoluteUrl,
             method: .get,
             headers: MobileContentApiHeaders.nonAuthorizedHeaders().getHeadersValue(),
             httpBody: nil,
             queryItems: nil
         )
-        .map { (response: RequestCodableResponse<JsonApiResponseDataArray<LanguageModel>>) in
-            response.codable?.dataArray ?? []
+        .map { (response: RequestCodableResponse<JsonApiResponseDataArray<LanguageModel>, NoResponseCodable>) in
+            response.successCodable?.dataArray ?? []
         }
         .catch { _ in
             return Just([])

--- a/Example/MobileContentApi/App/Share/Data/MobileContentApi/Resources/Language/LanguageResource.swift
+++ b/Example/MobileContentApi/App/Share/Data/MobileContentApi/Resources/Language/LanguageResource.swift
@@ -18,11 +18,13 @@ class LanguageResource: ApiResource {
         let resourceUrl = ApiResourceUrl(baseUrl: context.baseUrl, path: "languages")
         
         getLanguageEndpoint = GetLanguageEndpoint(
+            urlSession: context.urlSession,
             resourceUrl: resourceUrl,
             context: context
         )
         
         getLanguagesEndpoint = GetLanguagesEndpoint(
+            urlSession: context.urlSession,
             resourceUrl: resourceUrl,
             context: context
         )

--- a/Sources/RequestOperation/Api/RequestApiSharedContext.swift
+++ b/Sources/RequestOperation/Api/RequestApiSharedContext.swift
@@ -11,13 +11,13 @@ import Foundation
 open class RequestApiSharedContext {
     
     public let baseUrl: ApiBaseUrl
-    public let session: URLSession
+    public let urlSession: URLSession
     public let requestController: RequestController
     
-    public init(baseUrl: ApiBaseUrl, session: URLSession, requestController: RequestController) {
+    public init(baseUrl: ApiBaseUrl, urlSession: URLSession, requestController: RequestController) {
        
         self.baseUrl = baseUrl
-        self.session = session
+        self.urlSession = urlSession
         self.requestController = requestController
     }
 }

--- a/Sources/RequestOperation/RequestSender/RequestSender.swift
+++ b/Sources/RequestOperation/RequestSender/RequestSender.swift
@@ -10,19 +10,14 @@ import Foundation
 import Combine
 
 open class RequestSender {
+            
+    public init() {
         
-    public let session: URLSession
-    
-    public init(session: URLSession) {
-        
-        self.session = session
     }
     
-    open func sendDataTaskPublisher(urlRequest: URLRequest, urlSession: URLSession? = nil) -> AnyPublisher<RequestDataResponse, Error> {
-        
-        let session: URLSession = urlSession ?? self.session
-        
-        return session.dataTaskPublisher(for: urlRequest)
+    open func sendDataTaskPublisher(urlRequest: URLRequest, urlSession: URLSession) -> AnyPublisher<RequestDataResponse, Error> {
+                
+        return urlSession.dataTaskPublisher(for: urlRequest)
             .map { (tuple: (data: Data, response: URLResponse)) in
                 RequestDataResponse(
                     data: tuple.data,

--- a/Tests/RequestOperationTests/RequestSender/RequestSenderTests+Decode.swift
+++ b/Tests/RequestOperationTests/RequestSender/RequestSenderTests+Decode.swift
@@ -18,17 +18,17 @@ extension RequestSenderTests {
         
         let languageId: String = Self.englishLanguageId
         
-        let session: URLSession = RequestUrlSession.createIgnoreCacheSession(timeoutIntervalForRequest: timeoutSeconds)
+        let urlSession: URLSession = RequestUrlSession.createIgnoreCacheSession(timeoutIntervalForRequest: timeoutSeconds)
         
-        let urlRequest: URLRequest = buildGetLanguageUrlRequest(session: session, languageId: languageId)
+        let urlRequest: URLRequest = buildGetLanguageUrlRequest(urlSession: urlSession, languageId: languageId)
 
-        let requestSender = RequestSender(session: session)
+        let requestSender = RequestSender()
         
         let expectation = expectation(description: "")
         
         var responseRef: RequestCodableResponse<JsonApiResponseDataObject<LanguageModel>, NoResponseCodable>?
         
-        requestSender.sendDataTaskPublisher(urlRequest: urlRequest)
+        requestSender.sendDataTaskPublisher(urlRequest: urlRequest, urlSession: urlSession)
             .decodeRequestDataResponseForSuccessCodable()
             .sink { completion in
                 
@@ -53,17 +53,17 @@ extension RequestSenderTests {
         
         let languageId: String = Self.invalidLanguageId
         
-        let session: URLSession = RequestUrlSession.createIgnoreCacheSession(timeoutIntervalForRequest: timeoutSeconds)
+        let urlSession: URLSession = RequestUrlSession.createIgnoreCacheSession(timeoutIntervalForRequest: timeoutSeconds)
         
-        let urlRequest: URLRequest = buildGetLanguageUrlRequest(session: session, languageId: languageId)
+        let urlRequest: URLRequest = buildGetLanguageUrlRequest(urlSession: urlSession, languageId: languageId)
 
-        let requestSender = RequestSender(session: session)
+        let requestSender = RequestSender()
         
         let expectation = expectation(description: "")
         
         var responseRef: RequestCodableResponse<JsonApiResponseDataObject<LanguageModel>, NoResponseCodable>?
         
-        requestSender.sendDataTaskPublisher(urlRequest: urlRequest)
+        requestSender.sendDataTaskPublisher(urlRequest: urlRequest, urlSession: urlSession)
             .decodeRequestDataResponseForSuccessCodable()
             .sink { completion in
                 
@@ -87,17 +87,17 @@ extension RequestSenderTests {
         
         let languageId: String = Self.invalidLanguageId
         
-        let session: URLSession = RequestUrlSession.createIgnoreCacheSession(timeoutIntervalForRequest: timeoutSeconds)
+        let urlSession: URLSession = RequestUrlSession.createIgnoreCacheSession(timeoutIntervalForRequest: timeoutSeconds)
         
-        let urlRequest: URLRequest = buildGetLanguageUrlRequest(session: session, languageId: languageId)
+        let urlRequest: URLRequest = buildGetLanguageUrlRequest(urlSession: urlSession, languageId: languageId)
 
-        let requestSender = RequestSender(session: session)
+        let requestSender = RequestSender()
         
         let expectation = expectation(description: "")
         
         var responseRef: RequestCodableResponse<JsonApiResponseDataObject<LanguageModel>, MobileContentApiErrorsCodable>?
         
-        requestSender.sendDataTaskPublisher(urlRequest: urlRequest)
+        requestSender.sendDataTaskPublisher(urlRequest: urlRequest, urlSession: urlSession)
             .decodeRequestDataResponseForSuccessOrFailureCodable()
             .sink { completion in
                 
@@ -121,18 +121,18 @@ extension RequestSenderTests {
         
         let languageId: String = Self.englishLanguageId
         
-        let session: URLSession = RequestUrlSession.createIgnoreCacheSession(timeoutIntervalForRequest: timeoutSeconds)
+        let urlSession: URLSession = RequestUrlSession.createIgnoreCacheSession(timeoutIntervalForRequest: timeoutSeconds)
         
-        let urlRequest: URLRequest = buildGetLanguageUrlRequest(session: session, languageId: languageId)
+        let urlRequest: URLRequest = buildGetLanguageUrlRequest(urlSession: urlSession, languageId: languageId)
 
-        let requestSender = RequestSender(session: session)
+        let requestSender = RequestSender()
         
         let expectation = expectation(description: "")
         
         var decodeErrorRef: Error?
         var responseRef: RequestCodableResponse<JsonApiResponseDataObject<InvalidLanguageCodable>, NoResponseCodable>?
         
-        requestSender.sendDataTaskPublisher(urlRequest: urlRequest)
+        requestSender.sendDataTaskPublisher(urlRequest: urlRequest, urlSession: urlSession)
             .decodeRequestDataResponseForSuccessCodable()
             .sink { completion in
                 
@@ -165,18 +165,18 @@ extension RequestSenderTests {
         
         let languageId: String = Self.invalidLanguageId
         
-        let session: URLSession = RequestUrlSession.createIgnoreCacheSession(timeoutIntervalForRequest: timeoutSeconds)
+        let urlSession: URLSession = RequestUrlSession.createIgnoreCacheSession(timeoutIntervalForRequest: timeoutSeconds)
         
-        let urlRequest: URLRequest = buildGetLanguageUrlRequest(session: session, languageId: languageId)
+        let urlRequest: URLRequest = buildGetLanguageUrlRequest(urlSession: urlSession, languageId: languageId)
 
-        let requestSender = RequestSender(session: session)
+        let requestSender = RequestSender()
         
         let expectation = expectation(description: "")
         
         var decodeErrorRef: Error?
         var responseRef: RequestCodableResponse<JsonApiResponseDataObject<LanguageModel>, MobileContentApiErrorCodable>?
         
-        requestSender.sendDataTaskPublisher(urlRequest: urlRequest)
+        requestSender.sendDataTaskPublisher(urlRequest: urlRequest, urlSession: urlSession)
             .decodeRequestDataResponseForSuccessOrFailureCodable()
             .sink { completion in
                 

--- a/Tests/RequestOperationTests/RequestSender/RequestSenderTests+URLError.swift
+++ b/Tests/RequestOperationTests/RequestSender/RequestSenderTests+URLError.swift
@@ -16,7 +16,7 @@ extension RequestSenderTests {
         
         let timeoutSeconds: TimeInterval = 15
         
-        let session: URLSession = RequestUrlSession.createIgnoreCacheSession(timeoutIntervalForRequest: timeoutSeconds)
+        let urlSession: URLSession = RequestUrlSession.createIgnoreCacheSession(timeoutIntervalForRequest: timeoutSeconds)
         
         let requestBuilder = RequestBuilder()
         
@@ -27,7 +27,7 @@ extension RequestSenderTests {
         
         let urlRequest: URLRequest = requestBuilder.build(
             parameters: RequestBuilderParameters(
-                urlSession: session,
+                urlSession: urlSession,
                 urlString: urlString,
                 method: requestMethod,
                 headers: ["Content-Type": contentType],
@@ -36,13 +36,13 @@ extension RequestSenderTests {
             )
         )
 
-        let requestSender = RequestSender(session: session)
+        let requestSender = RequestSender()
         
         let expectation = expectation(description: "")
         
         var errorRef: Error?
         
-        requestSender.sendDataTaskPublisher(urlRequest: urlRequest)
+        requestSender.sendDataTaskPublisher(urlRequest: urlRequest, urlSession: urlSession)
             .sink { completion in
                 
                 switch completion {

--- a/Tests/RequestOperationTests/RequestSender/RequestSenderTests+Validate.swift
+++ b/Tests/RequestOperationTests/RequestSender/RequestSenderTests+Validate.swift
@@ -18,11 +18,11 @@ extension RequestSenderTests {
         
         let languageId: String = Self.invalidLanguageId
         
-        let session: URLSession = RequestUrlSession.createIgnoreCacheSession(timeoutIntervalForRequest: timeoutSeconds)
+        let urlSession: URLSession = RequestUrlSession.createIgnoreCacheSession(timeoutIntervalForRequest: timeoutSeconds)
         
-        let urlRequest: URLRequest = buildGetLanguageUrlRequest(session: session, languageId: languageId)
+        let urlRequest: URLRequest = buildGetLanguageUrlRequest(urlSession: urlSession, languageId: languageId)
 
-        let requestSender = RequestSender(session: session)
+        let requestSender = RequestSender()
         
         let expectation = expectation(description: "")
         
@@ -30,7 +30,7 @@ extension RequestSenderTests {
         
         var errorRef: Error?
         
-        requestSender.sendDataTaskPublisher(urlRequest: urlRequest)
+        requestSender.sendDataTaskPublisher(urlRequest: urlRequest, urlSession: urlSession)
             .validate(successRange: httpStatusCodeSuccessRange)
             .sink { completion in
                 
@@ -67,11 +67,11 @@ extension RequestSenderTests {
         
         let languageId: String = Self.englishLanguageId
         
-        let session: URLSession = RequestUrlSession.createIgnoreCacheSession(timeoutIntervalForRequest: timeoutSeconds)
+        let urlSession: URLSession = RequestUrlSession.createIgnoreCacheSession(timeoutIntervalForRequest: timeoutSeconds)
         
-        let urlRequest: URLRequest = buildGetLanguageUrlRequest(session: session, languageId: languageId)
+        let urlRequest: URLRequest = buildGetLanguageUrlRequest(urlSession: urlSession, languageId: languageId)
 
-        let requestSender = RequestSender(session: session)
+        let requestSender = RequestSender()
         
         let expectation = expectation(description: "")
         
@@ -79,7 +79,7 @@ extension RequestSenderTests {
         
         var responseRef: RequestDataResponse?
         
-        requestSender.sendDataTaskPublisher(urlRequest: urlRequest)
+        requestSender.sendDataTaskPublisher(urlRequest: urlRequest, urlSession: urlSession)
             .validate(successRange: httpStatusCodeSuccessRange)
             .sink { completion in
                 

--- a/Tests/RequestOperationTests/RequestSender/RequestSenderTests.swift
+++ b/Tests/RequestOperationTests/RequestSender/RequestSenderTests.swift
@@ -18,7 +18,7 @@ class RequestSenderTests: XCTestCase {
     
     var cancellables: Set<AnyCancellable> = Set()
     
-    func buildGetLanguageUrlRequest(session: URLSession, languageId: String) -> URLRequest {
+    func buildGetLanguageUrlRequest(urlSession: URLSession, languageId: String) -> URLRequest {
         
         let requestBuilder = RequestBuilder()
         
@@ -28,7 +28,7 @@ class RequestSenderTests: XCTestCase {
         
         let urlRequest: URLRequest = requestBuilder.build(
             parameters: RequestBuilderParameters(
-                urlSession: session,
+                urlSession: urlSession,
                 urlString: urlString,
                 method: requestMethod,
                 headers: ["Content-Type": contentType],
@@ -44,17 +44,17 @@ class RequestSenderTests: XCTestCase {
         
         let timeoutSeconds: TimeInterval = 15
         
-        let session: URLSession = RequestUrlSession.createIgnoreCacheSession(timeoutIntervalForRequest: timeoutSeconds)
+        let urlSession: URLSession = RequestUrlSession.createIgnoreCacheSession(timeoutIntervalForRequest: timeoutSeconds)
                 
-        let urlRequest: URLRequest = buildGetLanguageUrlRequest(session: session, languageId: Self.englishLanguageId)
+        let urlRequest: URLRequest = buildGetLanguageUrlRequest(urlSession: urlSession, languageId: Self.englishLanguageId)
 
-        let requestSender = RequestSender(session: session)
+        let requestSender = RequestSender()
         
         let expectation = expectation(description: "")
         
         var responseRef: RequestDataResponse?
         
-        requestSender.sendDataTaskPublisher(urlRequest: urlRequest)
+        requestSender.sendDataTaskPublisher(urlRequest: urlRequest, urlSession: urlSession)
             .sink { completion in
                 
                 expectation.fulfill()
@@ -75,17 +75,17 @@ class RequestSenderTests: XCTestCase {
         
         let timeoutSeconds: TimeInterval = 15
         
-        let session: URLSession = RequestUrlSession.createIgnoreCacheSession(timeoutIntervalForRequest: timeoutSeconds)
+        let urlSession: URLSession = RequestUrlSession.createIgnoreCacheSession(timeoutIntervalForRequest: timeoutSeconds)
         
-        let urlRequest: URLRequest = buildGetLanguageUrlRequest(session: session, languageId: Self.invalidLanguageId)
+        let urlRequest: URLRequest = buildGetLanguageUrlRequest(urlSession: urlSession, languageId: Self.invalidLanguageId)
         
-        let requestSender = RequestSender(session: session)
+        let requestSender = RequestSender()
         
         let expectation = expectation(description: "")
         
         var responseRef: RequestDataResponse?
         
-        requestSender.sendDataTaskPublisher(urlRequest: urlRequest)
+        requestSender.sendDataTaskPublisher(urlRequest: urlRequest, urlSession: urlSession)
             .sink { completion in
                 
                 expectation.fulfill()


### PR DESCRIPTION
Removed URLSession from RequestSender init and is now sent with the URLRequest. This way a RequestSender can be shared regardless of the URLSession.